### PR TITLE
Remove restapi version constraint

### DIFF
--- a/develop.cfg
+++ b/develop.cfg
@@ -55,7 +55,6 @@ collective.js.jqueryui = 2.1.8
 Unidecode = 1.0.23
 collective.z3cform.datagridfield = 1.5.3
 dnspython = 1.16.0
-plone.restapi = 8.33.2
 plone.schema = 1.3.0
 plone.app.vocabularies = 4.3.0
 urllib3 = 1.26.11


### PR DESCRIPTION
```
Version and requirements information containing plone.restapi:

  [versions] constraint on plone.restapi: 8.33.2

  Requirement of Plone==5.2.9: plone.restapi

  Requirement of plone.volto: plone.restapi>=8.41.0

  Requirement of plone.restapi: setuptools

  Requirement of plone.restapi: pytz

  Requirement of plone.restapi: python-dateutil

  Requirement of plone.restapi: plone.schema>=1.2.1

  Requirement of plone.restapi: plone.rest

  Requirement of plone.restapi: PyJWT>=1.7.0

  Requirement of plone.restapi: Products.CMFPlone>=5.2

While:

  Installing instance.

Error: The requirement ('plone.restapi>=8.41.0') is not allowed by your [versions] constraint (8.33.2)
```